### PR TITLE
feat: convert to self-contained Docker action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,13 @@ updates:
       all-deps:
         patterns:
           - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    groups:
+      all-deps:
+        patterns:
+          - "*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - docker
   workflow_dispatch:
     inputs:
       dry_run:
@@ -19,6 +20,7 @@ on:
 
 env:
   IMAGE: europe-north1-docker.pkg.dev/nais-management-7178/nais-verification/attest-sign
+  ACTION_IMAGE: ghcr.io/nais/attest-sign
 
 jobs:
   test:
@@ -27,6 +29,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      packages: write
 
     steps:
       - name: Checkout source
@@ -95,6 +98,18 @@ jobs:
           docker_context: 'test'
           project_id: 'nais-management-7178'
           identity_provider: 'projects/718161667033/locations/global/workloadIdentityPools/dev-nais-identity-pool/providers/github-oidc-provider'
+
+      - name: Build and push action Docker image
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          docker build --platform linux/amd64 \
+            -t "${{ env.ACTION_IMAGE }}:latest" \
+            -t "${{ env.ACTION_IMAGE }}:${{ steps.tags.outputs.deploy_tag }}" \
+            -t "${{ env.ACTION_IMAGE }}:${{ steps.tags.outputs.new_tag }}" \
+            .
+          docker push "${{ env.ACTION_IMAGE }}:latest"
+          docker push "${{ env.ACTION_IMAGE }}:${{ steps.tags.outputs.deploy_tag }}"
+          docker push "${{ env.ACTION_IMAGE }}:${{ steps.tags.outputs.new_tag }}"
 
       # We want to use the new changes
       - name: Attest and sign test image

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - docker
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea/
+misc/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,32 @@
+# Changes
+
+## What changed and why
+
+Third-party GitHub Actions (`sigstore/cosign-installer`, `oras-project/setup-oras`,
+`aquasecurity/trivy-action`) are a supply-chain risk. A compromised action can
+exfiltrate secrets or tamper with builds. We replaced them with a self-contained
+Docker image that installs the tools directly from upstream releases.
+
+## What's new
+
+- **`Dockerfile`** (repo root): Alpine-based image with pinned versions of
+  cosign v3.0.5, trivy v0.69.3, and oras v1.3.1.
+- **`entrypoint.sh`**: runs input validation, SBOM generation (trivy), signing
+  and attestation (cosign).
+- **`action.yml`**: rewritten as a composite action that handles caching via
+  `actions/cache` and runs the Docker image via `docker run`. All third-party
+  `uses:` steps removed.
+- **`.github/workflows/main.yml`**: builds and pushes the action Docker image to
+  GHCR (`ghcr.io/nais/attest-sign`) before the integration test. The test image
+  continues to go to GAR via `nais/docker-build-push`. Note: after the first
+  push, the GHCR package visibility must be set to **public** manually in GitHub
+  package settings (one-time step) so consumers can pull without authentication.
+- **`.github/dependabot.yml`**: added Dockerfile tracking for the root
+  Dockerfile.
+- **`README.md`**: documents the new architecture.
+
+## What's kept
+
+- `actions/cache` (first-party GitHub action) — still used for the trivy-java-db
+  cache.
+- The same inputs/outputs interface — callers don't need to change anything.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM alpine:3.21
+
+ARG COSIGN_VERSION=v3.0.5
+ARG TRIVY_VERSION=0.69.3
+ARG ORAS_VERSION=1.3.1
+
+RUN apk add --no-cache \
+    bash \
+    curl \
+    jq \
+    ca-certificates
+
+# Install cosign
+# Checksum from https://github.com/sigstore/cosign/releases/download/v3.0.5/cosign_checksums.txt
+RUN curl -fsSL "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64" \
+    -o /usr/local/bin/cosign \
+    && echo "db15cc99e6e4837daabab023742aaddc3841ce57f193d11b7c3e06c8003642b2  /usr/local/bin/cosign" | sha256sum -c - \
+    && chmod +x /usr/local/bin/cosign
+
+# Install trivy
+# Checksum from https://github.com/aquasecurity/trivy/releases/download/v0.69.3/trivy_0.69.3_checksums.txt
+RUN curl -fsSL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
+    -o /tmp/trivy.tar.gz \
+    && echo "1816b632dfe529869c740c0913e36bd1629cb7688bd5634f4a858c1d57c88b75  /tmp/trivy.tar.gz" | sha256sum -c - \
+    && tar -xz -f /tmp/trivy.tar.gz -C /usr/local/bin trivy \
+    && rm /tmp/trivy.tar.gz
+
+# Install oras
+# Checksum from https://github.com/oras-project/oras/releases/download/v1.3.1/oras_1.3.1_checksums.txt
+RUN curl -fsSL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" \
+    -o /tmp/oras.tar.gz \
+    && echo "d52c4af76ce6a3ceb8579e51fb751a43ac051cca67f965f973a0b0e897a2bb86  /tmp/oras.tar.gz" | sha256sum -c - \
+    && tar -xz -f /tmp/oras.tar.gz -C /usr/local/bin oras \
+    && rm /tmp/oras.tar.gz
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ jobs:
 
 ## Functionality
 
-The action uses Trivy to generate an SBOM and cosign to sign it. 
+The action uses Trivy to generate an SBOM and cosign to sign it.
 It implements caching of the `trivy-java-db` and multiple "mirrors/repositories" to avoid being rate-limited by Github and significantly reduce the time used on subsequent runs.
 The [trivy-java-db](https://github.com/aquasecurity/trivy-java-db/pkgs/container/trivy-java-db) is updated weekly so the cache should be updated at least as often.
+
+## Architecture
+
+The action is a **composite action** with a Docker inner runner:
+
+- The outer `action.yml` (composite) handles caching (`actions/cache`) and outputs.
+- All heavy lifting — Trivy SBOM generation, `cosign sign`, and `cosign attest` — runs inside a
+  Docker container built from the `Dockerfile` at the repo root.
+- Tools installed in the Docker image (pinned versions):
+  - [cosign](https://github.com/sigstore/cosign) v3.0.5
+  - [trivy](https://github.com/aquasecurity/trivy) v0.69.3
+  - [oras](https://github.com/oras-project/oras) v1.3.1
+- The only external GitHub Action used is `actions/cache` (first-party).

--- a/action.yml
+++ b/action.yml
@@ -73,9 +73,9 @@ runs:
           -e ACTIONS_ID_TOKEN_REQUEST_URL \
           -e ACTIONS_ID_TOKEN_REQUEST_TOKEN \
           $DOCKER_CONFIG_MOUNT \
-          -v "${{ github.workspace }}:/github/workspace" \
+          -v "$GITHUB_WORKSPACE:/github/workspace" \
           -w /github/workspace \
-          -v "${{ github.workspace }}/.trivy:/github/workspace/.trivy" \
+          -v "$GITHUB_WORKSPACE/.trivy:/github/workspace/.trivy" \
           "${ACTION_IMAGE}"
 
     - name: Fix .trivy permissions

--- a/action.yml
+++ b/action.yml
@@ -19,49 +19,33 @@ outputs:
   sbom:
     description: 'SBOM.json in cyclonedx format'
     value: ${{ steps.set-outputs.outputs.SBOM }}
+
 runs:
   using: 'composite'
   steps:
-    - name: 'Validate image ref'
-      env:
-        IMAGE_REF: ${{ inputs.image_ref }}
-      run: |
-        image_ref="${IMAGE_REF}"
-        if [[ $image_ref != *@sha256:* ]]; then
-          echo "Image must be in the form of <image>@<digest>"
-          exit 1
-        fi
-      shell: 'bash'
-    - name: 'Install cosign'
-      uses: 'sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003' # ratchet:sigstore/cosign-installer@v4.1.1
-      with:
-        cosign-release: 'v3.0.5'
-
-    # Check if the 'sbom' input is provided, and output a message if it is empty
-    - name: "Validate SBOM input"
-      env:
-        SBOM: ${{ inputs.sbom }}
-      shell: 'bash'
-      run: |
-        sbom="${SBOM}"
-        if [ -z "$sbom" ]; then
-          echo "SBOM input is empty. Please provide a valid SBOM for attestation."
-          exit 1
-        elif [[ ! $sbom =~ ^[a-zA-Z0-9._/-]+$ ]]; then
-          echo "Invalid SBOM filename or path: $sbom"
-          exit 1
-        else
-          echo "SBOM input is provided and valid: $sbom"
-        fi
-
-    - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # ratchet:oras-project/setup-oras@v2.0.0
-      name: Setup ORAS for manifest fetch
-
+    # NOTE: The action image is currently referenced by :latest.
+    # After the first release, pin this to a versioned tag or digest matching the action version
+    # (e.g. ghcr.io/nais/attest-sign:v2.0.1) for supply-chain reproducibility.
     - name: Fetch Trivy Java DB digest
       shell: 'bash'
       id: fetch-trivy-java-db-digest
       run: |
-        TRIVY_JAVA_DB_DIGEST=$(oras manifest fetch europe-north1-docker.pkg.dev/nais-io/remote-ghcr/aquasecurity/trivy-java-db:1 | jq -r '.layers[0].digest')
+        set -euo pipefail
+        ACTION_IMAGE="ghcr.io/nais/attest-sign:latest"
+        DOCKER_CONFIG_MOUNT=""
+        if [ -f "$HOME/.docker/config.json" ]; then
+          DOCKER_CONFIG_MOUNT="-v $HOME/.docker/config.json:/root/.docker/config.json:ro"
+        fi
+        TRIVY_JAVA_DB_DIGEST=$(docker run --rm \
+          --entrypoint oras \
+          $DOCKER_CONFIG_MOUNT \
+          "${ACTION_IMAGE}" \
+          manifest fetch europe-north1-docker.pkg.dev/nais-io/remote-ghcr/aquasecurity/trivy-java-db:1 \
+          | jq -r '.layers[0].digest')
+        if [ -z "$TRIVY_JAVA_DB_DIGEST" ]; then
+          echo "Failed to fetch Trivy Java DB digest"
+          exit 1
+        fi
         echo "TRIVY_JAVA_DB_DIGEST=$TRIVY_JAVA_DB_DIGEST" >> $GITHUB_OUTPUT
 
     - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # ratchet:actions/cache@v5
@@ -70,22 +54,30 @@ runs:
         path: .trivy
         key: trivy-db-${{ steps.fetch-trivy-java-db-digest.outputs.TRIVY_JAVA_DB_DIGEST }}
 
-    - name: 'Generate SBOM'
-      if: inputs.sbom == 'auto-generate-for-me-please.json'
-      uses: 'aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1' # ratchet:aquasecurity/trivy-action@0.35.0
+    - name: 'Sign and attest image'
+      shell: 'bash'
       env:
-        TRIVY_SKIP_DB_UPDATE: "true"
-        TRIVY_JAVA_DB_REPOSITORY: "${{ inputs.trivy_java_db_repositories }}"
-      with:
-        scan-type: 'image'
-        format: 'cyclonedx'
-        output: 'auto-generate-for-me-please.json'
-        image-ref: "${{ inputs.image_ref }}"
-        cache-dir: ".trivy"
-        # Pin version to avoid unexpected issues with new releases
-        version: "v0.69.3"
+        INPUT_IMAGE_REF: ${{ inputs.image_ref }}
+        INPUT_SBOM: ${{ inputs.sbom }}
+        INPUT_TRIVY_JAVA_DB_REPOSITORIES: ${{ inputs.trivy_java_db_repositories }}
+      run: |
+        ACTION_IMAGE="ghcr.io/nais/attest-sign:latest"
+        DOCKER_CONFIG_MOUNT=""
+        if [ -f "$HOME/.docker/config.json" ]; then
+          DOCKER_CONFIG_MOUNT="-v $HOME/.docker/config.json:/root/.docker/config.json:ro"
+        fi
+        docker run --rm \
+          -e INPUT_IMAGE_REF \
+          -e INPUT_SBOM \
+          -e INPUT_TRIVY_JAVA_DB_REPOSITORIES \
+          -e ACTIONS_ID_TOKEN_REQUEST_URL \
+          -e ACTIONS_ID_TOKEN_REQUEST_TOKEN \
+          $DOCKER_CONFIG_MOUNT \
+          -v "${{ github.workspace }}:/github/workspace" \
+          -w /github/workspace \
+          -v "${{ github.workspace }}/.trivy:/github/workspace/.trivy" \
+          "${ACTION_IMAGE}"
 
-        # See https://github.com/yogeshlonkar/trivy-cache-action?tab=readme-ov-file#trivy-cache-action-
     - name: Fix .trivy permissions
       shell: 'bash'
       run: |
@@ -94,42 +86,6 @@ runs:
         else
           echo ".trivy directory does not exist, skipping chown."
         fi
-
-    - name: Debug SBOM summary
-      if: inputs.sbom == 'auto-generate-for-me-please.json'
-      shell: bash
-      run: |
-        echo "=== SBOM file info ==="
-        ls -lh auto-generate-for-me-please.json
-
-        echo "=== CycloneDX metadata ==="
-        jq '{bomFormat, specVersion, metadata: {timestamp, tools}}' auto-generate-for-me-please.json
-
-        echo "=== Component count ==="
-        jq '.components | length' auto-generate-for-me-please.json
-
-        echo "=== First 2 components ==="
-        jq '.components[:2]' auto-generate-for-me-please.json
-
-    - name: 'Sign and attest image'
-      env:
-        IMAGE_REF: ${{ inputs.image_ref }}
-      shell: 'bash'
-      run: |
-        image_ref="${IMAGE_REF}"
-
-        if [ "${{ inputs.sbom }}" = "auto-generate-for-me-please.json" ]; then
-          sbom="auto-generate-for-me-please.json"
-        else
-          sbom="${{ inputs.sbom }}"
-        fi
-
-        echo "Using SBOM file: $sbom" 
-
-        cosign version
-        cosign sign --yes "${image_ref}"
-        cosign attest --yes --predicate "$sbom" --type cyclonedx  "${image_ref}"
-
 
     - name: Set outputs
       env:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,6 +22,11 @@ else
   echo "SBOM input is provided and valid: ${SBOM}"
 fi
 
+# Start signing in background while trivy runs in parallel
+cosign sign --yes "${IMAGE_REF}" > /tmp/cosign-sign.log 2>&1 &
+SIGN_PID=$!
+trap 'kill "$SIGN_PID" 2>/dev/null; wait "$SIGN_PID" 2>/dev/null || true' EXIT
+
 # Generate SBOM with Trivy if not provided
 if [ "${SBOM}" = "auto-generate-for-me-please.json" ]; then
   echo "Generating SBOM with Trivy..."
@@ -49,6 +54,9 @@ fi
 
 echo "Using SBOM file: ${SBOM}"
 
-cosign version
-cosign sign --yes "${IMAGE_REF}"
+# Wait for background sign to complete; propagates non-zero exit under set -e
+wait $SIGN_PID
+echo "=== cosign sign output ==="
+cat /tmp/cosign-sign.log
+trap - EXIT
 cosign attest --yes --predicate "${SBOM}" --type cyclonedx "${IMAGE_REF}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE_REF="${INPUT_IMAGE_REF}"
+SBOM="${INPUT_SBOM}"
+TRIVY_JAVA_DB_REPOSITORIES="${INPUT_TRIVY_JAVA_DB_REPOSITORIES}"
+
+# Validate image ref
+if [[ "${IMAGE_REF}" != *@sha256:* ]]; then
+  echo "Image must be in the form of <image>@<digest>"
+  exit 1
+fi
+
+# Validate SBOM input
+if [ -z "${SBOM}" ]; then
+  echo "SBOM input is empty. Please provide a valid SBOM for attestation."
+  exit 1
+elif [[ ! "${SBOM}" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+  echo "Invalid SBOM filename or path: ${SBOM}"
+  exit 1
+else
+  echo "SBOM input is provided and valid: ${SBOM}"
+fi
+
+# Generate SBOM with Trivy if not provided
+if [ "${SBOM}" = "auto-generate-for-me-please.json" ]; then
+  echo "Generating SBOM with Trivy..."
+
+  TRIVY_SKIP_DB_UPDATE=true \
+  TRIVY_JAVA_DB_REPOSITORY="${TRIVY_JAVA_DB_REPOSITORIES}" \
+  trivy image \
+    --format cyclonedx \
+    --output "auto-generate-for-me-please.json" \
+    --cache-dir ".trivy" \
+    "${IMAGE_REF}"
+
+  echo "=== SBOM file info ==="
+  ls -lh auto-generate-for-me-please.json
+
+  echo "=== CycloneDX metadata ==="
+  jq '{bomFormat, specVersion, metadata: {timestamp, tools}}' auto-generate-for-me-please.json
+
+  echo "=== Component count ==="
+  jq '.components | length' auto-generate-for-me-please.json
+
+  echo "=== First 2 components ==="
+  jq '.components[:2]' auto-generate-for-me-please.json
+fi
+
+echo "Using SBOM file: ${SBOM}"
+
+cosign version
+cosign sign --yes "${IMAGE_REF}"
+cosign attest --yes --predicate "${SBOM}" --type cyclonedx "${IMAGE_REF}"


### PR DESCRIPTION
Replace third-party GitHub Actions (sigstore/cosign-installer, oras-project/setup-oras, aquasecurity/trivy-action) with a Docker image that installs tools directly from verified upstream releases.
- Dockerfile: Alpine image with cosign v3.0.5, trivy v0.69.3, oras v1.3.1 (SHA256-verified)
- entrypoint.sh: validation, SBOM generation, signing, attestation
- action.yml: composite wrapper with docker run, only actions/cache remains
- CI: build and push action image to ghcr.io/nais/attest-sign