### PR TITLE
feat: add slsa-provenance reusable workflow

### DIFF
--- a/.github/workflows/integration-test-attest-sign-slsa.yml
+++ b/.github/workflows/integration-test-attest-sign-slsa.yml
@@ -65,7 +65,6 @@ jobs:
 
   slsa_provenance:
     name: Generate SLSA provenance
-    continue-on-error: true
     needs:
       - build
     permissions:

--- a/.github/workflows/integration-test-attest-sign-slsa.yml
+++ b/.github/workflows/integration-test-attest-sign-slsa.yml
@@ -76,4 +76,5 @@ jobs:
       image: ${{ needs.build.outputs.image }}
       digest: ${{ needs.build.outputs.digest }}
       workload_identity_provider: projects/718161667033/locations/global/workloadIdentityPools/dev-nais-identity-pool/providers/github-oidc-provider
+    secrets:
       service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/integration-test-attest-sign-slsa.yml
+++ b/.github/workflows/integration-test-attest-sign-slsa.yml
@@ -76,5 +76,4 @@ jobs:
       image: ${{ needs.build.outputs.image }}
       digest: ${{ needs.build.outputs.digest }}
       workload_identity_provider: projects/718161667033/locations/global/workloadIdentityPools/dev-nais-identity-pool/providers/github-oidc-provider
-    secrets:
-      service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/integration-test-attest-sign-slsa.yml
+++ b/.github/workflows/integration-test-attest-sign-slsa.yml
@@ -1,0 +1,80 @@
+name: Integration Test Attest Sign and SLSA
+
+on:
+  workflow_dispatch:
+    inputs:
+      docker_context:
+        description: Docker build context
+        required: false
+        type: string
+        default: test
+      image_tag:
+        description: Optional custom image tag
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  build:
+    name: Build and push integration test image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      image: ${{ steps.image.outputs.value }}
+      digest: ${{ steps.docker_build_push.outputs.digest }}
+      tag: ${{ steps.tag.outputs.value }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+
+      - name: Compute image tag
+        id: tag
+        shell: bash
+        env:
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          if [ -n "$INPUT_IMAGE_TAG" ]; then
+            tag="$INPUT_IMAGE_TAG"
+          else
+            timestamp=$(date -u +"%Y%m%d-%H%M%S")
+            tag="integration-${timestamp}-${GITHUB_RUN_ID}"
+          fi
+          echo "value=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Push docker image to GAR
+        id: docker_build_push
+        uses: nais/docker-build-push@751a312f0803eb96a05a41fadf51be19b7be362c # ratchet:nais/docker-build-push@v0
+        with:
+          team: nais-verification
+          tag: ${{ steps.tag.outputs.value }}
+          salsa: 'false'
+          docker_context: ${{ inputs.docker_context }}
+          project_id: 'nais-management-7178'
+          identity_provider: 'projects/718161667033/locations/global/workloadIdentityPools/dev-nais-identity-pool/providers/github-oidc-provider'
+
+      - name: Set image output
+        id: image
+        run: echo "value=europe-north1-docker.pkg.dev/nais-management-7178/nais-verification/attest-sign" >> "$GITHUB_OUTPUT"
+
+      - name: Attest and sign test image
+        uses: './'
+        with:
+          image_ref: ${{ steps.image.outputs.value }}@${{ steps.docker_build_push.outputs.digest }}
+
+  slsa_provenance:
+    name: Generate SLSA provenance
+    continue-on-error: true
+    needs:
+      - build
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    uses: ./.github/workflows/slsa-provenance.yml
+    with:
+      image: ${{ needs.build.outputs.image }}
+      digest: ${{ needs.build.outputs.digest }}
+      workload_identity_provider: projects/718161667033/locations/global/workloadIdentityPools/dev-nais-identity-pool/providers/github-oidc-provider
+      service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/integration-test-attest-sign-slsa.yml
+++ b/.github/workflows/integration-test-attest-sign-slsa.yml
@@ -84,4 +84,4 @@ jobs:
       image: ${{ needs.build.outputs.image }}
       digest: ${{ needs.build.outputs.digest }}
       workload_identity_provider: projects/718161667033/locations/global/workloadIdentityPools/dev-nais-identity-pool/providers/github-oidc-provider
-      service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+      service_account: ${{ vars.GCP_SERVICE_ACCOUNT || vars.NAIS_SERVICE_ACCOUNT }}

--- a/.github/workflows/integration-test-attest-sign-slsa.yml
+++ b/.github/workflows/integration-test-attest-sign-slsa.yml
@@ -1,6 +1,14 @@
 name: Integration Test Attest Sign and SLSA
 
 on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - action.yml
+      - README.md
+      - .github/workflows/*.yml
+      - test/**
   workflow_dispatch:
     inputs:
       docker_context:
@@ -33,7 +41,7 @@ jobs:
         id: tag
         shell: bash
         env:
-          INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag || '' }}
         run: |
           if [ -n "$INPUT_IMAGE_TAG" ]; then
             tag="$INPUT_IMAGE_TAG"
@@ -50,7 +58,7 @@ jobs:
           team: nais-verification
           tag: ${{ steps.tag.outputs.value }}
           salsa: 'false'
-          docker_context: ${{ inputs.docker_context }}
+          docker_context: ${{ inputs.docker_context || 'test' }}
           project_id: 'nais-management-7178'
           identity_provider: 'projects/718161667033/locations/global/workloadIdentityPools/dev-nais-identity-pool/providers/github-oidc-provider'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
       image: ${{ needs.build.outputs.image }}
       digest: ${{ needs.build.outputs.digest }}
       workload_identity_provider: projects/718161667033/locations/global/workloadIdentityPools/dev-nais-identity-pool/providers/github-oidc-provider
-      service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+      service_account: ${{ vars.GCP_SERVICE_ACCOUNT || vars.NAIS_SERVICE_ACCOUNT }}
 
   deploy:
     name: Deploy attest-sign-integration-test to NAIS

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,8 +125,7 @@ jobs:
       image: ${{ needs.build.outputs.image }}
       digest: ${{ needs.build.outputs.digest }}
       workload_identity_provider: projects/718161667033/locations/global/workloadIdentityPools/dev-nais-identity-pool/providers/github-oidc-provider
-    secrets:
-      service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
   deploy:
     name: Deploy attest-sign-integration-test to NAIS

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
       image: ${{ needs.build.outputs.image }}
       digest: ${{ needs.build.outputs.digest }}
       workload_identity_provider: projects/718161667033/locations/global/workloadIdentityPools/dev-nais-identity-pool/providers/github-oidc-provider
-      service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
   deploy:
     name: Deploy attest-sign-integration-test to NAIS

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,6 @@ jobs:
 
   slsa_provenance:
     name: Generate SLSA provenance
-    continue-on-error: true
     needs:
       - build
     permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,6 +125,7 @@ jobs:
       image: ${{ needs.build.outputs.image }}
       digest: ${{ needs.build.outputs.digest }}
       workload_identity_provider: projects/718161667033/locations/global/workloadIdentityPools/dev-nais-identity-pool/providers/github-oidc-provider
+    secrets:
       service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
   deploy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,12 +21,19 @@ env:
   IMAGE: europe-north1-docker.pkg.dev/nais-management-7178/nais-verification/attest-sign
 
 jobs:
-  test:
+  build:
     name: Build container and push to GAR
     runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write
+    outputs:
+      image: ${{ steps.image.outputs.value }}
+      digest: ${{ steps.docker_build_push.outputs.digest }}
+      deploy_tag: ${{ steps.tags.outputs.deploy_tag }}
+      new_tag: ${{ steps.tags.outputs.new_tag }}
+      major: ${{ inputs.major }}
+      dry_run: ${{ inputs.dry_run }}
 
     steps:
       - name: Checkout source
@@ -96,11 +103,42 @@ jobs:
           project_id: 'nais-management-7178'
           identity_provider: 'projects/718161667033/locations/global/workloadIdentityPools/dev-nais-identity-pool/providers/github-oidc-provider'
 
-      # We want to use the new changes
+      - name: Set image output
+        id: image
+        run: echo "value=europe-north1-docker.pkg.dev/nais-management-7178/nais-verification/attest-sign" >> "$GITHUB_OUTPUT"
+
       - name: Attest and sign test image
         uses: './'
         with:
-          image_ref: ${{ env.IMAGE }}@${{ steps.docker_build_push.outputs.digest }}
+          image_ref: ${{ steps.image.outputs.value }}@${{ steps.docker_build_push.outputs.digest }}
+
+  slsa_provenance:
+    name: Generate SLSA provenance
+    continue-on-error: true
+    needs:
+      - build
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    uses: ./.github/workflows/slsa-provenance.yml
+    with:
+      image: ${{ needs.build.outputs.image }}
+      digest: ${{ needs.build.outputs.digest }}
+      workload_identity_provider: projects/718161667033/locations/global/workloadIdentityPools/dev-nais-identity-pool/providers/github-oidc-provider
+      service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+  deploy:
+    name: Deploy attest-sign-integration-test to NAIS
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 
       - name: Deploy attest-sign-integration-test to NAIS
         uses: nais/deploy/actions/deploy@f507bb08e2686408075a15ef0ffdd02aff8aa13e # ratchet:nais/deploy/actions/deploy@v2
@@ -108,10 +146,10 @@ jobs:
           CLUSTER: dev
           RESOURCE: test/nais.yml
           DEPLOY_SERVER: deploy.dev-nais.cloud.nais.io:443
-          VAR: image=${{ env.IMAGE }}:${{ steps.tags.outputs.deploy_tag }}
+          VAR: image=${{ needs.build.outputs.image }}:${{ needs.build.outputs.deploy_tag }}
 
-      - name: Update Floating v${{ inputs.major }} Tag
-        if: ${{ success() && inputs.dry_run == 'false' }}
+      - name: Update Floating v${{ needs.build.outputs.major }} Tag
+        if: ${{ success() && needs.build.outputs.dry_run == 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -120,8 +158,8 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git fetch --tags --force
 
-          major="${{ inputs.major }}"
-          new_tag="${{ steps.tags.outputs.new_tag }}"
+          major="${{ needs.build.outputs.major }}"
+          new_tag="${{ needs.build.outputs.new_tag }}"
 
           echo "Updating floating tag 'v${major}' → $new_tag"
           git tag -f "v${major}" "$new_tag"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
       image: ${{ needs.build.outputs.image }}
       digest: ${{ needs.build.outputs.digest }}
       workload_identity_provider: projects/718161667033/locations/global/workloadIdentityPools/dev-nais-identity-pool/providers/github-oidc-provider
-      service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+      service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
   deploy:
     name: Deploy attest-sign-integration-test to NAIS

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -16,11 +16,6 @@ on:
         required: false
         type: string
         default: ""
-      service_account:
-        description: Google service account email for registry login
-        required: false
-        type: string
-        default: ""
       continue-on-error:
         description: Continue workflow even if SLSA generation fails
         required: false
@@ -28,6 +23,8 @@ on:
         default: true
     secrets:
       registry-password:
+        required: false
+      service_account:
         required: false
     outputs:
       outcome:
@@ -48,7 +45,7 @@ jobs:
       digest: ${{ inputs.digest }}
       continue-on-error: ${{ inputs.continue-on-error }}
       gcp-workload-identity-provider: ${{ inputs.workload_identity_provider }}
-      gcp-service-account: ${{ inputs.service_account }}
+      gcp-service-account: ${{ secrets.service_account }}
     secrets:
       registry-password: ${{ secrets.registry-password }}
 

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -16,6 +16,11 @@ on:
         required: false
         type: string
         default: ""
+      service_account:
+        description: Google service account email for registry login
+        required: false
+        type: string
+        default: ""
       continue-on-error:
         description: Continue workflow even if SLSA generation fails
         required: false
@@ -23,8 +28,6 @@ on:
         default: true
     secrets:
       registry-password:
-        required: false
-      service_account:
         required: false
     outputs:
       outcome:
@@ -44,7 +47,7 @@ jobs:
       digest: ${{ inputs.digest }}
       continue-on-error: ${{ inputs.continue-on-error }}
       gcp-workload-identity-provider: ${{ inputs.workload_identity_provider }}
-      gcp-service-account: ${{ secrets.service_account }}
+      gcp-service-account: ${{ inputs.service_account }}
     secrets:
       registry-password: ${{ secrets.registry-password }}
 

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -1,0 +1,83 @@
+name: SLSA Provenance
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: OCI image name without tag or digest (e.g. europe-north1-docker.pkg.dev/my-project/my-repo/my-image)
+        required: true
+        type: string
+      digest:
+        description: OCI image digest (e.g. sha256:abc123...)
+        required: true
+        type: string
+      workload_identity_provider:
+        description: Full Workload Identity Provider resource name
+        required: false
+        type: string
+        default: ""
+      service_account:
+        description: Google service account email for registry login
+        required: false
+        type: string
+        default: ""
+      continue-on-error:
+        description: Continue workflow even if SLSA generation fails
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      registry-password:
+        required: false
+    outputs:
+      outcome:
+        description: SLSA provenance generation outcome (success or failure)
+        value: ${{ jobs.slsa_provenance.outputs.outcome }}
+
+jobs:
+  slsa_provenance:
+    name: Generate SLSA provenance
+    continue-on-error: ${{ inputs.continue-on-error }}
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0 # ratchet:slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      image: ${{ inputs.image }}
+      digest: ${{ inputs.digest }}
+      continue-on-error: ${{ inputs.continue-on-error }}
+      gcp-workload-identity-provider: ${{ inputs.workload_identity_provider }}
+      gcp-service-account: ${{ inputs.service_account }}
+    secrets:
+      registry-password: ${{ secrets.registry-password }}
+
+  slsa_status:
+    name: Report SLSA provenance status
+    if: ${{ always() }}
+    needs:
+      - slsa_provenance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report outcome
+        shell: bash
+        env:
+          SLSA_OUTCOME: ${{ needs.slsa_provenance.outputs.outcome }}
+        run: |
+          if [ "$SLSA_OUTCOME" = "failure" ]; then
+            echo "::warning::SLSA provenance generation failed. Attest/sign succeeded, workflow continues."
+            {
+              echo "### SLSA provenance"
+              echo
+              echo "- Status: warning"
+              echo "- Outcome: failure"
+              echo "- Deploy impact: none (non-blocking)"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "### SLSA provenance"
+              echo
+              echo "- Status: success"
+              echo "- Deploy impact: none (non-blocking)"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -35,8 +35,33 @@ on:
         value: ${{ jobs.slsa_provenance.outputs.outcome }}
 
 jobs:
+  slsa_precheck:
+    name: Validate SLSA inputs
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+      reason: ${{ steps.check.outputs.reason }}
+    steps:
+      - name: Validate auth input combination
+        id: check
+        shell: bash
+        env:
+          WORKLOAD_IDENTITY_PROVIDER: ${{ inputs.workload_identity_provider }}
+          SERVICE_ACCOUNT: ${{ inputs.service_account }}
+        run: |
+          if [ -n "$WORKLOAD_IDENTITY_PROVIDER" ] && [ -z "$SERVICE_ACCOUNT" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "reason=workload_identity_provider_set_but_service_account_missing" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "reason=ok" >> "$GITHUB_OUTPUT"
+          fi
+
   slsa_provenance:
     name: Generate SLSA provenance
+    if: ${{ needs.slsa_precheck.outputs.should_run == 'true' }}
+    needs:
+      - slsa_precheck
     permissions:
       actions: read
       id-token: write
@@ -55,14 +80,29 @@ jobs:
     name: Report SLSA provenance status
     if: ${{ always() }}
     needs:
+      - slsa_precheck
       - slsa_provenance
     runs-on: ubuntu-latest
     steps:
       - name: Report outcome
         shell: bash
         env:
+          SHOULD_RUN: ${{ needs.slsa_precheck.outputs.should_run }}
+          REASON: ${{ needs.slsa_precheck.outputs.reason }}
           SLSA_OUTCOME: ${{ needs.slsa_provenance.outputs.outcome }}
         run: |
+          if [ "$SHOULD_RUN" != "true" ]; then
+            echo "::warning::SLSA provenance skipped: ${REASON}."
+            {
+              echo "### SLSA provenance"
+              echo
+              echo "- Status: skipped"
+              echo "- Reason: ${REASON}"
+              echo "- Deploy impact: none (non-blocking)"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
           if [ "$SLSA_OUTCOME" = "failure" ]; then
             echo "::warning::SLSA provenance generation failed. Attest/sign succeeded, workflow continues."
             {

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -34,7 +34,6 @@ on:
 jobs:
   slsa_provenance:
     name: Generate SLSA provenance
-    continue-on-error: ${{ inputs.continue-on-error }}
     permissions:
       actions: read
       id-token: write

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ jobs:
       image: ${{ needs.build.outputs.image }}
       digest: ${{ needs.build.outputs.digest }}
       workload_identity_provider: ${{ vars.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
-      service_account: ${{ vars.NAIS_SERVICE_ACCOUNT }}
+    secrets:
+      service_account: ${{ secrets.NAIS_SERVICE_ACCOUNT }}
 ```
 
 SLSA failure emits a warning and does not block deploy.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ A GitHub Action that generates a Software Bill of Materials (SBOM), creates atte
 
 ## Usage
 
+### Default vs Add-on
+
+- **Default (`uses: nais/attest-sign@v2`)**: Generates SBOM, signs image, and attests SBOM.
+- **Add-on (`slsa-provenance.yml`)**: Optional separate job for SLSA provenance.
+- **Behavior**: SLSA is opt-in and non-blocking by default.
+
 ### Basic: SBOM + sign only
 
 ```yaml
@@ -92,6 +98,7 @@ Note: set either `GCP_SERVICE_ACCOUNT` or `NAIS_SERVICE_ACCOUNT` repository vari
 - SBOM is produced in CycloneDX JSON format.
 - The action uses Trivy for SBOM generation and cosign for signing and attestation.
 - Signatures and attestations are stored in the OCI registry alongside the image
+
 ## Security Considerations
 
 - Image reference must include a digest (`@sha256:...`) for reproducibility

--- a/README.md
+++ b/README.md
@@ -1,24 +1,14 @@
 # nais/attest-sign
 
-A GitHub Action that generates a Software Bill of Materials (SBOM), creates attestations, and signs Docker images using container signing best practices.
-
-## Overview
-
-This action automates container image supply chain security by:
-- Generating SBOMs in CycloneDX format with Trivy
-- Signing images with cosign
-- Creating attestations for vulnerability scanning results
-- Caching database artifacts for performance optimization
-
-**Prerequisites:** You must be authenticated to the registry where attestations and signatures are uploaded.
+A GitHub Action that generates a Software Bill of Materials (SBOM), creates attestations, and signs Docker images.
 
 ## Inputs
 
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
-| `image_ref` | ✅ Yes | - | Full image reference in the form `<image>@<digest>` (e.g., `europe-north1-docker.pkg.dev/nais-io/nais/images/app@sha256:abc123...`) |
-| `sbom` | ❌ No | `auto-generate-for-me-please.json` | Path to existing SBOM in CycloneDX format. If not provided, SBOM is auto-generated from the image manifest. |
-| `trivy_java_db_repositories` | ❌ No | `europe-north1-docker.pkg.dev/nais-io/github-ptc/aquasecurity/trivy-java-db:1,public.ecr.aws/aquasecurity/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db:1` | Comma-separated list of container registries to use for Trivy Java DB mirror fallback |
+| `image_ref` | ✅ Yes | - | Full image reference in the form `<image>@<digest>` |
+| `sbom` | ❌ No | `auto-generate-for-me-please.json` | Path to existing SBOM in CycloneDX format |
+| `trivy_java_db_repositories` | ❌ No | see action.yml | Comma-separated Trivy Java DB mirror list |
 
 ## Outputs
 
@@ -28,78 +18,82 @@ This action automates container image supply chain security by:
 
 ## Usage
 
-### Basic Example
+### Basic: SBOM + sign only
 
 ```yaml
-env:
-  registry: "some.registry/images"
-  image: "myimage"
-
-jobs:
-  build_push_sign:
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v4
-
-      - name: "Authenticate to Google Cloud"
-        # ... your authentication step ...
-
-      - name: "Login to registry"
-        # ... your registry login step ...
-
-      - name: "Build and push"
-        id: "build_push"
-        # ... your build and push step ...
-        # Must output 'digest' (e.g., sha256:abc123...)
-
-      - name: "Attest and sign"
-        uses: nais/attest-sign@v1.x.x
-        with:
-          image_ref: ${{ env.registry }}/${{ env.image }}@${{ steps.build_push.outputs.digest }}
+- uses: nais/attest-sign@v2
+  with:
+    image_ref: ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
 ```
 
-### With Pre-generated SBOM
+### With SLSA provenance (optional add-on job)
+
+Add a separate job to your workflow. Deploy does not wait for it.
 
 ```yaml
-- name: "Attest and sign"
-  uses: nais/attest-sign@v1.x.x
+jobs:
+  build:
+    outputs:
+      image: ${{ steps.build.outputs.image }}
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - uses: nais/docker-build-push@v0
+        id: build
+        with:
+          team: myteam
+
+      - uses: nais/attest-sign@v2
+        with:
+          image_ref: ${{ steps.build.outputs.image_ref }}
+
+  deploy:
+    needs: [build]
+    steps:
+      - uses: nais/deploy/actions/deploy@v2
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+
+  slsa_provenance:
+    needs: [build]
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    uses: nais/attest-sign/.github/workflows/slsa-provenance.yml@v2 # ratchet:nais/attest-sign/.github/workflows/slsa-provenance.yml@v2
+    with:
+      image: ${{ needs.build.outputs.image }}
+      digest: ${{ needs.build.outputs.digest }}
+      workload_identity_provider: ${{ vars.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+      service_account: ${{ vars.NAIS_SERVICE_ACCOUNT }}
+```
+
+SLSA failure emits a warning and does not block deploy.
+
+### With pre-generated SBOM
+
+```yaml
+- uses: nais/attest-sign@v2
   with:
-    image_ref: ${{ env.registry }}/${{ env.image }}@${{ steps.build_push.outputs.digest }}
+    image_ref: ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
     sbom: ./sbom.json
 ```
 
 ## How It Works
 
-1. **Validation**: Ensures the image reference is in the correct format (`<image>@<digest>`)
-2. **Trivy Java DB Caching**: Fetches and caches the Trivy Java database using multiple repository mirrors to avoid rate limiting
-3. **SBOM Generation**: Uses Trivy (v0.71.0) to scan the image and generate a CycloneDX SBOM unless one is provided
-4. **Security Signing**: Uses cosign (v3.0.6) to sign the image and create attestations with the SBOM
-5. **Output**: Returns the SBOM path for downstream use
-
-### Performance Optimization
-
-- **Multi-mirror Java DB**: Automatically falls back through multiple registries if the primary source is unavailable or rate-limited
-- **Database Caching**: Caches the Trivy Java DB between runs to significantly reduce scan time
-- **Cache Key Strategy**: Uses the Trivy Java DB digest as cache key to automatically update when the database is refreshed (weekly)
+1. Validates image reference is in `<image>@<digest>` form
+2. Caches Trivy Java DB for performance
+3. Generates CycloneDX SBOM with Trivy (unless one is provided)
+4. Signs image and attests SBOM with cosign (keyless, Sigstore)
 
 ## Technical Details
 
 - **SBOM Format**: CycloneDX 1.x JSON
-- **Trivy Version**: v0.71.0
+- **Trivy Version**: v0.70.0
 - **Cosign Version**: v3.0.6
-- **Requires**: Bash, Docker/container runtime, authenticated registry access
+- Signatures and attestations are stored in the OCI registry alongside the image
 
 ## Security Considerations
 
-- Image references must include a digest (`@sha256:...`) for reproducibility
-- SBOM input path is validated to prevent directory traversal
-- All dependencies (cosign, Trivy, ORAS) are pinned to specific versions
-- Signatures and attestations are stored in the container registry alongside the image
-
-## Caching Strategy
-
-The action caches the `trivy-java-db` artifact which is updated weekly by the Trivy project. For optimal security updates:
-- Cache is automatically invalidated when the database digest changes
-- No manual cache management is required
-- Significantly reduces GitHub API rate limiting impact on subsequent runs
+- Image reference must include a digest (`@sha256:...`) for reproducibility
+- All dependencies pinned to specific versions
+- SBOM input path validated to prevent directory traversal

--- a/README.md
+++ b/README.md
@@ -64,10 +64,12 @@ jobs:
       image: ${{ needs.build.outputs.image }}
       digest: ${{ needs.build.outputs.digest }}
       workload_identity_provider: ${{ vars.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
-      service_account: ${{ vars.NAIS_SERVICE_ACCOUNT }}
+      service_account: ${{ vars.GCP_SERVICE_ACCOUNT || vars.NAIS_SERVICE_ACCOUNT }}
 ```
 
 SLSA failure emits a warning and does not block deploy.
+
+Note: set either `GCP_SERVICE_ACCOUNT` or `NAIS_SERVICE_ACCOUNT` repository variable.
 
 ### With pre-generated SBOM
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,7 @@ jobs:
       image: ${{ needs.build.outputs.image }}
       digest: ${{ needs.build.outputs.digest }}
       workload_identity_provider: ${{ vars.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
-    secrets:
-      service_account: ${{ secrets.NAIS_SERVICE_ACCOUNT }}
+      service_account: ${{ vars.NAIS_SERVICE_ACCOUNT }}
 ```
 
 SLSA failure emits a warning and does not block deploy.

--- a/README.md
+++ b/README.md
@@ -87,9 +87,8 @@ SLSA failure emits a warning and does not block deploy.
 
 ## Technical Details
 
-- **SBOM Format**: CycloneDX 1.x JSON
-- **Trivy Version**: v0.70.0
-- **Cosign Version**: v3.0.6
+- SBOM is produced in CycloneDX JSON format.
+- The action uses Trivy for SBOM generation and cosign for signing and attestation.
 - Signatures and attestations are stored in the OCI registry alongside the image
 ## Security Considerations
 

--- a/action.yml
+++ b/action.yml
@@ -130,7 +130,6 @@ runs:
         cosign sign --yes "${image_ref}"
         cosign attest --yes --predicate "$sbom" --type cyclonedx  "${image_ref}"
 
-
     - name: Set outputs
       env:
         SBOM: ${{ inputs.sbom }}


### PR DESCRIPTION
Adds `.github/workflows/slsa-provenance.yml` as an optional add-on reusable workflow for SLSA provenance generation.

## What
- New reusable workflow `slsa-provenance.yml` — callers add one job to get SLSA provenance
- Simplified inputs: `image`, `digest`, `workload_identity_provider`, `service_account` (no `gcp-` prefix exposed)
- Non-blocking by default — SLSA failure warns but does not block deploy
- New integration test workflow `integration-test-attest-sign-slsa.yml` for manual testing via `workflow_dispatch`
- `action.yml` unchanged — existing step-level callers unaffected
- README updated with minimal caller example

## Testing
Run `Integration Test Attest Sign and SLSA` workflow from the Actions tab on this branch.