### PR TITLE
chore: split CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     name: Build image and run action
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    outputs:
+      image_ref: ${{ steps.image_ref.outputs.image_ref }}
     permissions:
       contents: read
       id-token: write
@@ -48,3 +50,44 @@ jobs:
         uses: './'
         with:
           image_ref: ${{ steps.docker_build_push.outputs.image }}@${{ steps.docker_build_push.outputs.digest }}
+
+      - name: Export image ref
+        id: image_ref
+        run: |
+          echo "image_ref=${{ steps.docker_build_push.outputs.image }}@${{ steps.docker_build_push.outputs.digest }}" >> "$GITHUB_OUTPUT"
+
+  deploy-preview:
+    name: Deploy preview job to dev
+    if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
+
+      - name: Compute preview job name
+        id: preview
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -e
+
+          safe_ref=$(printf '%s' "$REF_NAME" | tr '/[:upper:]' '-[:lower:]' | tr -cd 'a-z0-9-')
+          safe_ref=${safe_ref#-}
+          safe_ref=${safe_ref%-}
+          safe_ref=${safe_ref:0:35}
+          name="attest-sign-${safe_ref}-it"
+
+          echo "name=${name}" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy preview to NAIS
+        uses: nais/deploy/actions/deploy@2d18f050f07b6a007864c6a57070ed915d571beb # ratchet:nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: dev-gcp
+          RESOURCE: test/nais.yml
+          VAR: image=${{ needs.validate.outputs.image_ref }},name=${{ steps.preview.outputs.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI for Attest Sign
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+concurrency:
+  group: attest-sign-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Build image and run action
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
+
+      - name: Compute CI image tag
+        id: tags
+        env:
+          REF_NAME: ${{ github.head_ref || github.ref_name }}
+        run: |
+          set -e
+
+          safe_ref=$(printf '%s' "$REF_NAME" | tr '/[:upper:]' '-[:lower:]' | tr -cd 'a-z0-9._-')
+          image_tag="ci-${safe_ref}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+          echo "image_tag=${image_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Push docker image to GAR
+        id: docker_build_push
+        uses: nais/docker-build-push@05dbb6091b30bd84279c6d64a45ef8782fd410a5 # ratchet:nais/docker-build-push@v0
+        with:
+          team: nais-verification
+          tag: ${{ steps.tags.outputs.image_tag }}
+          salsa: 'false'
+          docker_context: 'test'
+
+      - name: Attest and sign test image
+        uses: './'
+        with:
+          image_ref: ${{ steps.docker_build_push.outputs.image }}@${{ steps.docker_build_push.outputs.digest }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,9 @@ on:
   push:
     branches:
       - '**'
-  pull_request:
 
 concurrency:
-  group: attest-sign-ci-${{ github.event.pull_request.number || github.ref }}
+  group: attest-sign-ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build, Tag, and Push Image for Attest Sign Integration Test
+name: Release and Deploy Attest Sign Integration Test
 
 on:
   push:
@@ -17,13 +17,15 @@ on:
         description: "Major version number to use for the release tag."
         default: "2"
 
-env:
-  IMAGE: europe-north1-docker.pkg.dev/nais-management-7178/nais-verification/attest-sign
+concurrency:
+  group: attest-sign-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
     name: Build container and push to GAR
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       id-token: write
@@ -34,12 +36,14 @@ jobs:
 
       - name: Compute next release & deployment tags
         id: tags
+        env:
+          REQUESTED_MAJOR: ${{ inputs.major || '2' }}
         run: |
           set -e
 
           git fetch --tags --force
 
-          requested_major="${{ inputs.major }}"
+          requested_major="${REQUESTED_MAJOR}"
           latest_tag=$(git tag -l "v${requested_major}.*" | sort -V | tail -n 1 || echo "")
 
           if [ -z "$latest_tag" ]; then
@@ -69,7 +73,7 @@ jobs:
         if: success()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DRY_RUN: ${{ inputs.dry_run }}
+          DRY_RUN: ${{ inputs.dry_run || 'true' }}
         run: |
           set -e
           git config --global user.name "github-actions[bot]"
@@ -93,34 +97,33 @@ jobs:
           tag: ${{ steps.tags.outputs.deploy_tag }}
           salsa: 'false'
           docker_context: 'test'
-          project_id: 'nais-management-7178'
-          identity_provider: 'projects/718161667033/locations/global/workloadIdentityPools/dev-nais-identity-pool/providers/github-oidc-provider'
 
       # We want to use the new changes
       - name: Attest and sign test image
         uses: './'
         with:
-          image_ref: ${{ env.IMAGE }}@${{ steps.docker_build_push.outputs.digest }}
+          image_ref: ${{ steps.docker_build_push.outputs.image }}@${{ steps.docker_build_push.outputs.digest }}
 
       - name: Deploy attest-sign-integration-test to NAIS
-        uses: nais/deploy/actions/deploy@5fdd91aaf69bb0d6dd5e5118cdacb639f487b93b # ratchet:nais/deploy/actions/deploy@v2
+        uses: nais/deploy/actions/deploy@2d18f050f07b6a007864c6a57070ed915d571beb # ratchet:nais/deploy/actions/deploy@v2
         env:
           CLUSTER: dev
           RESOURCE: test/nais.yml
           DEPLOY_SERVER: deploy.dev-nais.cloud.nais.io:443
-          VAR: image=${{ env.IMAGE }}:${{ steps.tags.outputs.deploy_tag }}
+          VAR: image=${{ steps.docker_build_push.outputs.image }}@${{ steps.docker_build_push.outputs.digest }}
 
-      - name: Update Floating v${{ inputs.major }} Tag
-        if: ${{ success() && inputs.dry_run == 'false' }}
+      - name: Update Floating major tag
+        if: ${{ success() && (inputs.dry_run || 'true') == 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUESTED_MAJOR: ${{ inputs.major || '2' }}
         run: |
           set -e
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git fetch --tags --force
 
-          major="${{ inputs.major }}"
+          major="${REQUESTED_MAJOR}"
           new_tag="${{ steps.tags.outputs.new_tag }}"
 
           echo "Updating floating tag 'v${major}' → $new_tag"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,9 +107,8 @@ jobs:
       - name: Deploy attest-sign-integration-test to NAIS
         uses: nais/deploy/actions/deploy@2d18f050f07b6a007864c6a57070ed915d571beb # ratchet:nais/deploy/actions/deploy@v2
         env:
-          CLUSTER: dev
+          CLUSTER: dev-gcp
           RESOURCE: test/nais.yml
-          DEPLOY_SERVER: deploy.dev-nais.cloud.nais.io:443
           VAR: image=${{ steps.docker_build_push.outputs.image }}@${{ steps.docker_build_push.outputs.digest }}
 
       - name: Update Floating major tag

--- a/test/nais.yml
+++ b/test/nais.yml
@@ -1,8 +1,8 @@
 apiVersion: nais.io/v1
 kind: Naisjob
 metadata:
-  name: attest-sign-integration-test
+  name: {{ name }}
   namespace: nais-verification
 spec:
   image: {{ image }}
-  ttl: 5m
+  ttl: 10m


### PR DESCRIPTION
## Hva
- splitter workflowen i CI og release
- erstatter `main.yml` med `release.yml`
- legger til `ci.yml` for brancher, PR-er og Dependabot

## Hvorfor
CI verifiserer nå selve actionen på brancher og PR-er, mens release/deploy fortsatt bare kjører fra main eller manuelt.