### PR TITLE
feat: support merged SBOM inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,28 @@ jobs:
           docker_context: 'test'
 
       - name: Attest and sign test image
+        id: attest_sign
         uses: './'
         with:
           image_ref: ${{ steps.docker_build_push.outputs.image }}@${{ steps.docker_build_push.outputs.digest }}
+          sbom: auto-generate-for-me-please.json
+          additional_sboms: |
+            test/npm-sbom.json
+
+      - name: Verify merged SBOM output
+        run: |
+          set -e
+
+          sbom='${{ steps.attest_sign.outputs.sbom }}'
+          test "$sbom" = 'merged-sbom.json'
+
+          jq -e '.components[] | select(.name == "npm-lib" and .version == "1.2.3")' "$sbom" >/dev/null
+
+          component_count=$(jq '.components | length' "$sbom")
+          if [ "$component_count" -le 1 ]; then
+            echo "Expected merged SBOM to contain both image and npm components, got $component_count component(s)."
+            exit 1
+          fi
 
       - name: Export image ref
         id: image_ref

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,13 @@ jobs:
             test/npm-sbom.json
 
       - name: Verify merged SBOM output
+        env:
+          FINAL_SBOM: ${{ steps.attest_sign.outputs.sbom }}
         run: |
           set -e
 
-          sbom='${{ steps.attest_sign.outputs.sbom }}'
-          test "$sbom" = 'merged-sbom.json'
+          sbom="$FINAL_SBOM"
+          test -f "$sbom"
 
           jq -e '.components[] | select(.name == "npm-lib" and .version == "1.2.3")' "$sbom" >/dev/null
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ This action automates container image supply chain security by:
 |-------|----------|---------|-------------|
 | `image_ref` | ✅ Yes | - | Full image reference in the form `<image>@<digest>` (e.g., `europe-north1-docker.pkg.dev/nais-io/nais/images/app@sha256:abc123...`) |
 | `sbom` | ❌ No | `auto-generate-for-me-please.json` | Path to existing SBOM in CycloneDX format. If not provided, SBOM is auto-generated from the image manifest. |
+| `additional_sboms` | ❌ No | `''` | Newline-separated list of extra CycloneDX SBOM files to merge with the primary SBOM before attestation. Missing files fail the action. |
 | `trivy_java_db_repositories` | ❌ No | `europe-north1-docker.pkg.dev/nais-io/github-ptc/aquasecurity/trivy-java-db:1,public.ecr.aws/aquasecurity/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db:1` | Comma-separated list of container registries to use for Trivy Java DB mirror fallback |
 
 ## Outputs
 
 | Output | Description |
 |--------|-------------|
-| `sbom` | Path to the generated or provided SBOM in CycloneDX JSON format |
+| `sbom` | Path to the generated, provided, or merged SBOM in CycloneDX JSON format |
 
 ## Usage
 
@@ -69,13 +70,29 @@ jobs:
     sbom: ./sbom.json
 ```
 
+### With merged SBOMs
+
+```yaml
+- name: "Attest and sign"
+  uses: nais/attest-sign@v1.x.x
+  with:
+    image_ref: ${{ env.registry }}/${{ env.image }}@${{ steps.build_push.outputs.digest }}
+    sbom: auto-generate-for-me-please.json
+    additional_sboms: |
+      frontend-sbom.json
+      backend-sbom.json
+```
+
+Use this when you want one combined CycloneDX SBOM with both image dependencies and application dependencies. `byosbom` still accepts one file, so this action merges the SBOMs before attestation.
+
 ## How It Works
 
 1. **Validation**: Ensures the image reference is in the correct format (`<image>@<digest>`)
 2. **Trivy Java DB Caching**: Fetches and caches the Trivy Java database using multiple repository mirrors to avoid rate limiting
-3. **SBOM Generation**: Uses Trivy (v0.71.0) to scan the image and generate a CycloneDX SBOM unless one is provided
-4. **Security Signing**: Uses cosign (v3.0.6) to sign the image and create attestations with the SBOM
-5. **Output**: Returns the SBOM path for downstream use
+3. **SBOM Generation**: Uses Trivy (v0.70.0) to scan the image and generate a CycloneDX SBOM unless one is provided
+4. **SBOM Merge**: Merges the primary SBOM with any extra CycloneDX SBOM files if `additional_sboms` is set
+5. **Security Signing**: Uses cosign (v3.0.6) to sign the image and create attestations with the final SBOM
+6. **Output**: Returns the final SBOM path for downstream use
 
 ### Performance Optimization
 
@@ -87,6 +104,7 @@ jobs:
 
 - Image references must include a digest (`@sha256:...`) for reproducibility
 - SBOM input path is validated to prevent directory traversal
+- Missing files in `additional_sboms` fail the action immediately
 - All dependencies (cosign, Trivy, ORAS) are pinned to specific versions
 - Signatures and attestations are stored in the container registry alongside the image
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Use this when you want one combined CycloneDX SBOM with both image dependencies 
 ## Security Considerations
 
 - Image references must include a digest (`@sha256:...`) for reproducibility
-- SBOM input path is validated to prevent directory traversal
+- Provided SBOM files must exist before the action runs, except `auto-generate-for-me-please.json`
 - Missing files in `additional_sboms` fail the action immediately
 - All dependencies (cosign, Trivy, ORAS) are pinned to specific versions
 - Signatures and attestations are stored in the container registry alongside the image

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,9 @@ inputs:
   sbom:
     description: 'existing SBOM in cyclonedx format'
     default: 'auto-generate-for-me-please.json'
+  additional_sboms:
+    description: 'newline-separated list of extra CycloneDX SBOM files to merge with the primary SBOM'
+    default: ''
   trivy_java_db_repositories:
     description: 'specify the --java-db-repository strings for Trivy'
     default: "europe-north1-docker.pkg.dev/nais-io/github-ptc/aquasecurity/trivy-java-db:1,public.ecr.aws/aquasecurity/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db:1"
@@ -54,6 +57,29 @@ runs:
           echo "SBOM input is provided and valid: $sbom"
         fi
 
+    - name: 'Validate additional SBOM inputs'
+      env:
+        ADDITIONAL_SBOMS: ${{ inputs.additional_sboms }}
+      shell: 'bash'
+      run: |
+        while IFS= read -r sbom; do
+          [ -z "$sbom" ] && continue
+
+          if [[ ! $sbom =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+            echo "Invalid SBOM filename or path: $sbom"
+            exit 1
+          fi
+
+          if [ ! -f "$sbom" ]; then
+            echo "SBOM file does not exist: $sbom"
+            exit 1
+          fi
+
+          echo "Additional SBOM input is provided and valid: $sbom"
+        done <<EOF
+        ${ADDITIONAL_SBOMS}
+        EOF
+
     - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # ratchet:oras-project/setup-oras@v2.0.0
       name: Setup ORAS for manifest fetch
 
@@ -95,34 +121,80 @@ runs:
           echo ".trivy directory does not exist, skipping chown."
         fi
 
+    - name: Install cyclonedx-cli
+      if: inputs.additional_sboms != ''
+      shell: 'bash'
+      run: |
+        set -e
+
+        version='v0.32.0'
+        download_url='https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.32.0/cyclonedx-linux-x64'
+        expected_sha='454879e6a4a405c8a13bff49b8982adcb0596f3019b26b0811c66e4d7f0783e1'
+
+        curl -fsSL "$download_url" -o cyclonedx
+        echo "$expected_sha  cyclonedx" | sha256sum --check --status
+        chmod +x cyclonedx
+        sudo mv cyclonedx /usr/local/bin/cyclonedx
+
+    - name: Prepare final SBOM
+      id: prepare-sbom
+      env:
+        SBOM: ${{ inputs.sbom }}
+        ADDITIONAL_SBOMS: ${{ inputs.additional_sboms }}
+      shell: 'bash'
+      run: |
+        set -e
+
+        if [ "$SBOM" = "auto-generate-for-me-please.json" ]; then
+          primary_sbom='auto-generate-for-me-please.json'
+        else
+          primary_sbom="$SBOM"
+        fi
+
+        final_sbom="$primary_sbom"
+        merged_sbom='merged-sbom.json'
+        sboms=("$primary_sbom")
+
+        while IFS= read -r sbom; do
+          [ -z "$sbom" ] && continue
+          sboms+=("$sbom")
+        done <<EOF
+        ${ADDITIONAL_SBOMS}
+        EOF
+
+        if [ "${#sboms[@]}" -gt 1 ]; then
+          cyclonedx merge --input-files "${sboms[@]}" --output-file "$merged_sbom" --output-format json
+          final_sbom="$merged_sbom"
+        fi
+
+        echo "final_sbom=$final_sbom" >> "$GITHUB_OUTPUT"
+
     - name: Debug SBOM summary
-      if: inputs.sbom == 'auto-generate-for-me-please.json'
       shell: bash
       run: |
+        sbom='${{ steps.prepare-sbom.outputs.final_sbom }}'
+
         echo "=== SBOM file info ==="
-        ls -lh auto-generate-for-me-please.json
+        ls -lh "$sbom"
 
         echo "=== CycloneDX metadata ==="
-        jq '{bomFormat, specVersion, metadata: {timestamp, tools}}' auto-generate-for-me-please.json
+        jq '{bomFormat, specVersion, metadata: {timestamp, tools}}' "$sbom"
 
         echo "=== Component count ==="
-        jq '.components | length' auto-generate-for-me-please.json
+        jq '.components | length' "$sbom"
 
         echo "=== First 2 components ==="
-        jq '.components[:2]' auto-generate-for-me-please.json
+        jq '.components[:2]' "$sbom"
 
     - name: 'Sign and attest image'
       env:
         IMAGE_REF: ${{ inputs.image_ref }}
+        FINAL_SBOM: ${{ steps.prepare-sbom.outputs.final_sbom }}
       shell: 'bash'
       run: |
         image_ref="${IMAGE_REF}"
 
-        if [ "${{ inputs.sbom }}" = "auto-generate-for-me-please.json" ]; then
-          sbom="auto-generate-for-me-please.json"
-        else
-          sbom="${{ inputs.sbom }}"
-        fi
+        sbom="${FINAL_SBOM}"
 
         echo "Using SBOM file: $sbom" 
 
@@ -132,10 +204,8 @@ runs:
 
 
     - name: Set outputs
-      env:
-        SBOM: ${{ inputs.sbom }}
       shell: bash
       id: set-outputs
       run: |
-        sbom="${SBOM}"
+        sbom='${{ steps.prepare-sbom.outputs.final_sbom }}'
         echo "SBOM=$sbom" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -50,8 +50,8 @@ runs:
         if [ -z "$sbom" ]; then
           echo "SBOM input is empty. Please provide a valid SBOM for attestation."
           exit 1
-        elif [[ ! $sbom =~ ^[a-zA-Z0-9._/-]+$ ]]; then
-          echo "Invalid SBOM filename or path: $sbom"
+        elif [ "$sbom" != "auto-generate-for-me-please.json" ] && [ ! -f "$sbom" ]; then
+          echo "SBOM file does not exist: $sbom"
           exit 1
         else
           echo "SBOM input is provided and valid: $sbom"
@@ -64,11 +64,6 @@ runs:
       run: |
         while IFS= read -r sbom; do
           [ -z "$sbom" ] && continue
-
-          if [[ ! $sbom =~ ^[a-zA-Z0-9._/-]+$ ]]; then
-            echo "Invalid SBOM filename or path: $sbom"
-            exit 1
-          fi
 
           if [ ! -f "$sbom" ]; then
             echo "SBOM file does not exist: $sbom"

--- a/action.yml
+++ b/action.yml
@@ -162,12 +162,18 @@ runs:
           final_sbom="$merged_sbom"
         fi
 
-        echo "final_sbom=$final_sbom" >> "$GITHUB_OUTPUT"
+        {
+          echo 'final_sbom<<EOF'
+          printf '%s\n' "$final_sbom"
+          echo 'EOF'
+        } >> "$GITHUB_OUTPUT"
 
     - name: Debug SBOM summary
+      env:
+        FINAL_SBOM: ${{ steps.prepare-sbom.outputs.final_sbom }}
       shell: bash
       run: |
-        sbom='${{ steps.prepare-sbom.outputs.final_sbom }}'
+        sbom="${FINAL_SBOM}"
 
         echo "=== SBOM file info ==="
         ls -lh "$sbom"
@@ -199,8 +205,14 @@ runs:
 
 
     - name: Set outputs
+      env:
+        FINAL_SBOM: ${{ steps.prepare-sbom.outputs.final_sbom }}
       shell: bash
       id: set-outputs
       run: |
-        sbom='${{ steps.prepare-sbom.outputs.final_sbom }}'
-        echo "SBOM=$sbom" >> $GITHUB_OUTPUT
+        sbom="${FINAL_SBOM}"
+        {
+          echo 'SBOM<<EOF'
+          printf '%s\n' "$sbom"
+          echo 'EOF'
+        } >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -147,7 +147,6 @@ runs:
         fi
 
         final_sbom="$primary_sbom"
-        merged_sbom='merged-sbom.json'
         sboms=("$primary_sbom")
 
         while IFS= read -r sbom; do
@@ -158,6 +157,7 @@ runs:
         EOF
 
         if [ "${#sboms[@]}" -gt 1 ]; then
+          merged_sbom="$(mktemp "${RUNNER_TEMP}/merged-sbom.XXXXXX.json")"
           cyclonedx merge --input-files "${sboms[@]}" --output-file "$merged_sbom" --output-format json --output-version v1_6
           final_sbom="$merged_sbom"
         fi

--- a/action.yml
+++ b/action.yml
@@ -158,7 +158,7 @@ runs:
         EOF
 
         if [ "${#sboms[@]}" -gt 1 ]; then
-          cyclonedx merge --input-files "${sboms[@]}" --output-file "$merged_sbom" --output-format json
+          cyclonedx merge --input-files "${sboms[@]}" --output-file "$merged_sbom" --output-format json --output-version v1_6
           final_sbom="$merged_sbom"
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -128,7 +128,7 @@ runs:
         set -e
 
         version='v0.32.0'
-        download_url='https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.32.0/cyclonedx-linux-x64'
+        download_url="https://github.com/CycloneDX/cyclonedx-cli/releases/download/${version}/cyclonedx-linux-x64"
         expected_sha='454879e6a4a405c8a13bff49b8982adcb0596f3019b26b0811c66e4d7f0783e1'
 
         curl -fsSL "$download_url" -o cyclonedx

--- a/test/npm-sbom.json
+++ b/test/npm-sbom.json
@@ -1,0 +1,20 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "name": "npm-fixture",
+      "version": "1.0.0"
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "npm-lib",
+      "version": "1.2.3",
+      "purl": "pkg:npm/npm-lib@1.2.3"
+    }
+  ]
+}


### PR DESCRIPTION
## Hva
- legger til støtte for å merge flere CycloneDX SBOM-er før attestering
- oppdaterer CI til å teste image SBOM + npm SBOM
- oppdaterer README med brukseksempel

## Hvorfor
Dette gjør at vi kan sende inn én samlet SBOM med både image-avhengigheter og app-avhengigheter.