### PR TITLE
fix: retry cosign signing on transient Rekor `409` conflicts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -197,11 +197,28 @@ runs:
 
         sbom="${FINAL_SBOM}"
 
-        echo "Using SBOM file: $sbom" 
+        echo "Using SBOM file: $sbom"
 
         cosign version
-        cosign sign --yes "${image_ref}"
-        cosign attest --yes --predicate "$sbom" --type cyclonedx  "${image_ref}"
+
+        retry() {
+          local -r max_attempts=3
+          local attempt=1
+          local delay=5
+          until "$@"; do
+            if (( attempt >= max_attempts )); then
+              echo "cosign failed after ${max_attempts} attempts: $*" >&2
+              return 1
+            fi
+            echo "cosign failed (attempt ${attempt}/${max_attempts}); retrying in ${delay}s..." >&2
+            sleep "$delay"
+            attempt=$(( attempt + 1 ))
+            delay=$(( delay * 3 ))
+          done
+        }
+
+        retry cosign sign --yes "${image_ref}" \
+          && retry cosign attest --yes --predicate "$sbom" --type cyclonedx "${image_ref}"
 
 
     - name: Set outputs


### PR DESCRIPTION
`cosign` v3's Rekor upload is non-idempotent: a client-side timeout can retry into a `409` `createLogEntryConflict`, which aborts before the signature is attached to the
image.
Keyless re-signing mints fresh ephemeral keys, so a full retry writes a new transparency-log entry and completes the attach.
A `409` that survives every attempt is anomalous, so let it fail the step rather than shipping an unsigned image.
